### PR TITLE
Remove obsolete command line flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ copy_old:
 	cp -R ./old/* ./build
 
 spanify:
-	dart -c tool/spanify.dart --html src/index.template.html src/text.md \
+	dart tool/spanify.dart --html src/index.template.html src/text.md \
 	  > web/index.html


### PR DESCRIPTION
`-c` is no longer a `dart` command line flag. We have `--enable-asserts`, but that's too verbose. I just dropped it.